### PR TITLE
Change i3status submodule to a simply nix file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,9 +35,6 @@
 [submodule "nix/libleak"]
 	path = nix/libleak
 	url = https://github.com/SimulaVR/libleak
-[submodule "submodules/i3status"]
-	path = submodules/i3status
-	url = https://github.com/SimulaVR/i3status
 [submodule "submodules/monado"]
 	path = submodules/monado
 	url = https://github.com/SimulaVR/monado-xv.git

--- a/Simula.nix
+++ b/Simula.nix
@@ -46,7 +46,7 @@ let
 
     ghc-version = ghc.version;
 
-    i3status = callPackage ./submodules/i3status/i3status.nix {};
+    i3status = callPackage ./submodules/i3status {};
 
     devBuildFalse = ''
       ln -s ${godot}/bin/godot.x11.opt.debug.64 $out/bin/godot.x11.opt.debug.64

--- a/submodules/i3status/add-simula-mode.patch
+++ b/submodules/i3status/add-simula-mode.patch
@@ -1,0 +1,58 @@
+diff --git a/i3status.c b/i3status.c
+index 0898da3..55a0974 100644
+--- a/i3status.c
++++ b/i3status.c
+@@ -612,6 +612,8 @@ int main(int argc, char *argv[]) {
+         output_format = O_LEMONBAR;
+     else if (strcasecmp(output_str, "term") == 0)
+         output_format = O_TERM;
++    else if (strcasecmp(output_str, "simula") == 0)
++        output_format = O_SIMULA;
+     else if (strcasecmp(output_str, "none") == 0)
+         output_format = O_NONE;
+     else
+diff --git a/include/i3status.h b/include/i3status.h
+index 217376a..ea02d40 100644
+--- a/include/i3status.h
++++ b/include/i3status.h
+@@ -7,7 +7,8 @@ typedef enum {
+     O_I3BAR,
+     O_LEMONBAR,
+     O_TERM,
+-    O_NONE
++    O_NONE,
++    O_SIMULA
+ } output_format_t;
+ extern output_format_t output_format;
+
+diff --git a/src/output.c b/src/output.c
+index 937fa60..ddc9c96 100644
+--- a/src/output.c
++++ b/src/output.c
+@@ -40,6 +40,8 @@ char *color(const char *colorstr) {
+         int b = (col & (0xFF << 16)) / 0x800000;
+         col = (r << 2) | (g << 1) | b;
+         (void)snprintf(colorbuf, sizeof(colorbuf), "\033[3%d;1m", col);
++    } else if (output_format == O_SIMULA) {
++        (void)snprintf(colorbuf, sizeof(colorbuf), "[color=%s]", cfg_getstr(cfg_general, colorstr));
+     }
+     return colorbuf;
+ }
+@@ -51,6 +53,8 @@ char *color(const char *colorstr) {
+ char *endcolor(void) {
+     if (output_format == O_XMOBAR)
+         return "</fc>";
++    else if (output_format == O_SIMULA)
++        return "[/color]";
+     else if (output_format == O_TERM)
+         return "\033[0m";
+     else
+@@ -71,6 +75,8 @@ void print_separator(const char *separator) {
+         printf("%s%s%s", color("color_separator"), separator, endcolor());
+     else if (output_format == O_NONE)
+         printf("%s", separator);
++    else if (output_format == O_SIMULA)
++        printf("%s", separator);
+ }
+
+ /*

--- a/submodules/i3status/default.nix
+++ b/submodules/i3status/default.nix
@@ -1,0 +1,59 @@
+{
+  fetchurl,
+  lib,
+  stdenv,
+  libconfuse,
+  yajl,
+  alsa-lib,
+  libpulseaudio,
+  libnl,
+  meson,
+  ninja,
+  perl,
+  pkg-config,
+  asciidoc,
+  xmlto,
+  docbook_xml_dtd_45,
+  docbook_xsl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "i3status-with-simula-mode";
+  version = "2.15";
+
+  src = fetchurl {
+    url = "https://i3wm.org/i3status/i3status-${version}.tar.xz";
+    sha256 = "sha256-bGf1LK5PE533ZK0cxzZWK+D5d1B5G8IStT80wG6vIgU=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    perl
+    pkg-config
+    asciidoc
+    xmlto
+    docbook_xml_dtd_45
+    docbook_xsl
+  ];
+  buildInputs = [
+    libconfuse
+    yajl
+    alsa-lib
+    libpulseaudio
+    libnl
+  ];
+
+  patches = [
+    ./add-simula-mode.patch
+  ];
+
+  meta = {
+    description = "Generates a status line for i3bar, dzen2, xmobar or lemonbar";
+    homepage = "https://i3wm.org";
+    maintainers = [ ];
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    mainProgram = "i3status";
+  };
+}


### PR DESCRIPTION
# This PR's targets

- Reduce the amount of code
- Be successed for `i3status` build
  - I changed `alsaLib` to `alsa-lib` to use `nixpkgs-24.05` for build.

# Breaking points

- Original i3status version was `2.13`. I upgraded to `2.15`.
  - This change might break some process.